### PR TITLE
Remove react-hook-form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
         "@tauri-apps/api": "^1.3.0",
         "nanoid": "^4.0.2",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-hook-form": "^7.43.9"
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^1.3.0",
@@ -3470,21 +3469,6 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-hook-form": {
-      "version": "7.43.9",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
-      "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-hook-form"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "@tauri-apps/api": "^1.3.0",
     "nanoid": "^4.0.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-hook-form": "^7.43.9"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^1.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
     return <div className="container">...Setting up tododay</div>;
   }
 
-  return <Form initialFormState={formStateRef.current} />;
+  return <Form initialTodos={formStateRef.current} />;
 }
 
 export default App;

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useReducer } from "react";
-import { useForm } from "react-hook-form";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import { appWindow } from "@tauri-apps/api/window";
 
 import { appStateReducer } from "./appStateReducer";
 import { useKeyboardNavigation } from "./hooks/useKeyboardNavigation";
 import { Syncer } from "./Syncer";
-import type { AppState, FormValues } from "./types";
+import type { AppState } from "./types";
 import "./Form.css";
 
 type Props = {
@@ -14,35 +13,39 @@ type Props = {
 
 export const Form = ({ initialFormState = {} }: Props) => {
   const [state, dispatch] = useReducer(appStateReducer, initialFormState);
-  const { register, reset, handleSubmit, setFocus } = useForm<FormValues>();
+  const formRef = useRef<HTMLFormElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useKeyboardNavigation();
 
   useEffect(() => {
     const unlisten = appWindow.onFocusChanged(({ payload: focused }) => {
       if (focused) {
-        setFocus("todo");
+        inputRef.current?.focus();
       }
     });
 
     return () => {
       unlisten.then((f) => f());
     };
-  }, [setFocus]);
+  }, []);
 
-  const onSubmit = handleSubmit(({ todo }) => {
-    const content = todo.trim();
+  const handleSubmit = useCallback((ev: React.FormEvent<HTMLFormElement>) => {
+    ev.preventDefault();
 
-    if (!content) {
+    const data = new FormData(ev.currentTarget);
+    const content = data.get("todo");
+
+    if (typeof content !== "string" || !content.trim()) {
       return;
     }
 
     dispatch({
       type: "ADD",
-      content,
+      content: content.trim(),
     });
-    reset();
-  });
+    formRef.current?.reset();
+  }, []);
 
   const handleCheck = useCallback((id: string, isComplete: boolean) => {
     const type = isComplete ? "UNCOMPLETE" : "COMPLETE";
@@ -62,8 +65,8 @@ export const Form = ({ initialFormState = {} }: Props) => {
   return (
     <div className="container">
       <div className="row">
-        <form onSubmit={onSubmit} method="POST">
-          <input {...register("todo")} placeholder="Enter your todo..." />
+        <form onSubmit={handleSubmit} method="POST" ref={formRef}>
+          <input name="todo" placeholder="Enter your todo..." ref={inputRef} />
           <button type="submit">Add</button>
         </form>
       </div>

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -8,11 +8,11 @@ import type { AppState } from "./types";
 import "./Form.css";
 
 type Props = {
-  initialFormState: AppState;
+  initialTodos: AppState;
 };
 
-export const Form = ({ initialFormState = {} }: Props) => {
-  const [state, dispatch] = useReducer(appStateReducer, initialFormState);
+export const Form = ({ initialTodos = {} }: Props) => {
+  const [state, dispatch] = useReducer(appStateReducer, initialTodos);
   const formRef = useRef<HTMLFormElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 


### PR DESCRIPTION
Replacing [react-hook-form](https://www.npmjs.com/package/react-hook-form) with handrolled form handling, for the following reasons:
- Dedicated lib is a little overkill for the current use-case
- There was a bug when submitting the same todo twice

There's no functionality loss with this change