### PR TITLE
Allow re-ordering using keyboard

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -16,7 +16,7 @@ export const Form = ({ initialTodos = {} }: Props) => {
   const formRef = useRef<HTMLFormElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useKeyboardNavigation();
+  useKeyboardNavigation(dispatch);
 
   useEffect(() => {
     const unlisten = appWindow.onFocusChanged(({ payload: focused }) => {

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -1,25 +1,29 @@
 import { useEffect } from "react";
 
-const getFocusedN = (): number | null => {
+import { MOVE } from '../types';
+
+const getFocusedN = (): { idx: number | null, id: string | null } => {
     const focused = document.querySelector("input[data-n]:focus");
 
     if (!focused) {
-        return null;
+        return {
+            idx: null,
+            id: null,
+        };
     }
 
     const attrVal = focused.getAttribute("data-n");
+    const id = focused.getAttribute("id");
 
-
-    if (!attrVal) {
-        return null;
-    }
-
-    return parseInt(attrVal);
+    return {
+        id: id ?? null,
+        idx: attrVal ? parseInt(attrVal) : null,
+    };
 };
 
 const getAllCheckboxes = (): NodeListOf<HTMLInputElement> => document.querySelectorAll("input[data-n]");
 
-export const useKeyboardNavigation = () => {
+export const useKeyboardNavigation = (dispatch: React.Dispatch<MOVE>) => {
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
             const { key } = event;
@@ -40,27 +44,66 @@ export const useKeyboardNavigation = () => {
                 return;
             }
 
-            const focusedN = getFocusedN();
+            const isOptionDepressed = event.getModifierState("Alt");
+            const { id, idx } = getFocusedN();
 
-            if (key === "ArrowUp") {
-                // null or 0
-                if (!focusedN) {
-                    // last checkbox
-                    checkboxes[checkboxes.length - 1].focus();
-                } else {
-                    // 1 prior
-                    checkboxes[focusedN - 1].focus();
+            if (isOptionDepressed) {
+                if (key === "ArrowUp") {
+                    if (idx === null || !id) {
+                        // do nothing
+                    } else if (idx === 0) {
+                        dispatch({
+                            destinationIndex: checkboxes.length - 1,
+                            id: id,
+                            type: "MOVE",
+                        })
+                    } else {
+                        dispatch({
+                            destinationIndex: idx - 1,
+                            id: id,
+                            type: "MOVE",
+                        })
+                    }
                 }
-            }
-
-            if (key === "ArrowDown") {
-                // not focused or last item focused
-                if (focusedN === null || focusedN === checkboxes.length - 1) {
-                    // first checkbox
-                    checkboxes[0].focus();
-                } else {
-                    // 1 after
-                    checkboxes[focusedN + 1].focus();
+    
+                if (key === "ArrowDown") {
+                    if (idx === null || !id) {
+                        // do nothing
+                    } else if (idx === checkboxes.length - 1) {
+                        dispatch({
+                            destinationIndex: 0,
+                            id: id,
+                            type: "MOVE",
+                        })
+                    } else {
+                        dispatch({
+                            destinationIndex: idx + 1,
+                            id: id,
+                            type: "MOVE",
+                        })
+                    }
+                }
+            } else {
+                if (key === "ArrowUp") {
+                    // null or 0
+                    if (!idx) {
+                        // last checkbox
+                        checkboxes[checkboxes.length - 1].focus();
+                    } else {
+                        // 1 prior
+                        checkboxes[idx - 1].focus();
+                    }
+                }
+    
+                if (key === "ArrowDown") {
+                    // not focused or last item focused
+                    if (idx === null || idx === checkboxes.length - 1) {
+                        // first checkbox
+                        checkboxes[0].focus();
+                    } else {
+                        // 1 after
+                        checkboxes[idx + 1].focus();
+                    }
                 }
             }
         }
@@ -70,5 +113,5 @@ export const useKeyboardNavigation = () => {
         return () => {
             document.removeEventListener('keydown', handleKeyDown);
         }
-    });
+    }, [dispatch]);
 };

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -48,10 +48,14 @@ export const useKeyboardNavigation = (dispatch: React.Dispatch<MOVE>) => {
             const { id, idx } = getFocusedN();
 
             if (isOptionDepressed) {
+                // No checkbox focused - skip
+                if (idx === null || !id) {
+                    return;
+                }
+
                 if (key === "ArrowUp") {
-                    if (idx === null || !id) {
-                        // do nothing
-                    } else if (idx === 0) {
+                    // first checkbox should overflow to bottom of list
+                    if (idx === 0) {
                         dispatch({
                             destinationIndex: checkboxes.length - 1,
                             id: id,
@@ -64,12 +68,13 @@ export const useKeyboardNavigation = (dispatch: React.Dispatch<MOVE>) => {
                             type: "MOVE",
                         })
                     }
+
+                    return;
                 }
     
                 if (key === "ArrowDown") {
-                    if (idx === null || !id) {
-                        // do nothing
-                    } else if (idx === checkboxes.length - 1) {
+                    // last checkbox should overflow to top of list
+                    if (idx === checkboxes.length - 1) {
                         dispatch({
                             destinationIndex: 0,
                             id: id,
@@ -82,29 +87,34 @@ export const useKeyboardNavigation = (dispatch: React.Dispatch<MOVE>) => {
                             type: "MOVE",
                         })
                     }
+
+                    return;
                 }
-            } else {
-                if (key === "ArrowUp") {
-                    // null or 0
-                    if (!idx) {
-                        // last checkbox
-                        checkboxes[checkboxes.length - 1].focus();
-                    } else {
-                        // 1 prior
-                        checkboxes[idx - 1].focus();
-                    }
+            }
+
+            if (key === "ArrowUp") {
+                // null or 0
+                if (!idx) {
+                    checkboxes[checkboxes.length - 1].focus();
+                } else {
+                    // 1 prior
+                    checkboxes[idx - 1].focus();
                 }
-    
-                if (key === "ArrowDown") {
-                    // not focused or last item focused
-                    if (idx === null || idx === checkboxes.length - 1) {
-                        // first checkbox
-                        checkboxes[0].focus();
-                    } else {
-                        // 1 after
-                        checkboxes[idx + 1].focus();
-                    }
+
+                return;
+            }
+
+            if (key === "ArrowDown") {
+                // not focused or last item focused
+                if (idx === null || idx === checkboxes.length - 1) {
+                    // first checkbox
+                    checkboxes[0].focus();
+                } else {
+                    // 1 after
+                    checkboxes[idx + 1].focus();
                 }
+
+                return;
             }
         }
 


### PR DESCRIPTION
For users which prefer keyboard; this allows the re-ordering of todos using the up and down arrow keys, alongside the "alt" modifier; which varies depending on OS:
<img width="753" alt="image" src="https://github.com/JonShort/tododay/assets/21317379/198dcbf5-062a-4fcd-9cfb-e1aa505556b9">

Difficult to make the up / down handling code "clean" - imagine I could make it easier to read with abstraction but ultimately the logic would be the same