### PR TITLE
Add UI hinting at undo functionality

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -3,11 +3,12 @@ import { appWindow } from "@tauri-apps/api/window";
 import { nanoid } from "nanoid";
 
 import { useKeyboardNavigation } from "./hooks/useKeyboardNavigation";
-import { useUndo } from "./hooks/useUndo";
 import { Syncer } from "./Syncer";
+import { UndoHandler } from "./UndoHandler";
 import { useOptimisticReducer } from "./hooks/useOptimisticReducer";
-import type { AppState } from "./types";
 import "./Form.css";
+
+import type { AppState } from "./types";
 
 type Props = {
   initialTodos: AppState;
@@ -19,7 +20,6 @@ export const Form = ({ initialTodos = {} }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   useKeyboardNavigation(dispatch);
-  useUndo(dispatch);
 
   useEffect(() => {
     const unlisten = appWindow.onFocusChanged(({ payload: focused }) => {
@@ -139,6 +139,8 @@ export const Form = ({ initialTodos = {} }: Props) => {
       <div className="sync-container">
         <Syncer appState={state} />
       </div>
+
+      <UndoHandler dispatch={dispatch} />
     </div>
   );
 };

--- a/src/UndoHandler.css
+++ b/src/UndoHandler.css
@@ -1,0 +1,22 @@
+.undo-handler {
+  background: var(--background);
+  bottom: 0;
+  left: 0;
+  padding-left: 4vw;
+  position: fixed;
+  transition: transform 0.1s ease-in-out;
+  width: calc(100% - 4vw);
+}
+
+.undo-handler.shown {
+  transform: translateY(0px);
+}
+
+.undo-handler.hidden {
+  transform: translateY(20px);
+}
+
+.undo-message {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 0.8rem;
+}

--- a/src/UndoHandler.tsx
+++ b/src/UndoHandler.tsx
@@ -1,0 +1,18 @@
+import { useUndo } from "./hooks/useUndo";
+import type { OptimisticDispatch, UNREMOVE } from "./types";
+
+import "./UndoHandler.css";
+
+type Props = {
+  dispatch: OptimisticDispatch<UNREMOVE>;
+};
+
+export const UndoHandler = ({ dispatch }: Props) => {
+  const showUndoUI = useUndo(dispatch);
+
+  return (
+    <div className={`undo-handler ${showUndoUI ? "shown" : "hidden"}`}>
+      <span className="undo-message">Todo deleted - undo with cmd + z</span>
+    </div>
+  );
+};


### PR DESCRIPTION
First implementation of the undo UI - hinting to users that they can use `cmd + z` to undo

I added the "undo" button as seen in the wireframe but it just seemed too intrusive, the simple text message gives the information, without making it annoying for users that frequently delete todos

Because of the "hint" style approach, I also didn't need to give any information on the todo removed

### Issues
The text is currently macOS-specific, this can be made OS-specific using Tauri's OS api ([link](https://tauri.app/v1/api/js/os/#ostype)) but for this first implementation I'll keep it macOS specific

### Wireframe
![image](https://github.com/JonShort/tododay/assets/21317379/3a3ed084-59b8-4642-a3b1-87f1ae1beac3)

### Implementation
https://github.com/JonShort/tododay/assets/21317379/2813f9b7-b294-4a79-b5ab-ac3b0511ce05