### PR TITLE
Reduce del prominence

### DIFF
--- a/src/Form.css
+++ b/src/Form.css
@@ -47,9 +47,13 @@
 }
 
 .todo .todo__content {
+  -webkit-hyphens: auto;
   cursor: pointer;
   flex-grow: 1;
+  hyphens: auto;
+  overflow-wrap: anywhere;
   padding: 0.7rem;
+  word-break: normal;
 }
 
 .button__del {

--- a/src/Form.css
+++ b/src/Form.css
@@ -43,7 +43,12 @@
 
 .todo:hover,
 .todo:focus-within {
-  background: rgba(var(--color-rgb), 0.2);
+  background: rgba(var(--color-rgb), 0.08);
+}
+
+.todo:hover .button__del,
+.todo:focus-within .button__del {
+  opacity: 1;
 }
 
 .todo .todo__content {
@@ -57,9 +62,10 @@
 }
 
 .button__del {
-  padding: 0.5rem 1rem;
-  color: rgba(var(--color-rgb), 0.2);
-  background: rgba(var(--bkg-rgb), 0.3);
+  background: rgba(var(--bkg-rgb), 0.8);
+  color: rgba(var(--color-rgb), 0.5);
+  opacity: 0;
+  padding: 0.5rem 0.75rem;
 }
 
 .sync-container {

--- a/src/style.css
+++ b/src/style.css
@@ -51,6 +51,7 @@ button {
   border: 1px solid transparent;
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
   color: var(--btn-color);
+  flex-shrink: 0;
   font-family: inherit;
   font-size: 1em;
   font-weight: 500;


### PR DESCRIPTION
This PR hides the delete buttons by default, only showing them on hover or focus. It also fixes an issue where extremely long words would not break, and makes them wrap with a hyphen.

If we think about the information a user needs when looking at tododay, it would be:
* How many todos do I have remaining?
* What is the content of each todo?
* Is the todo completed?
* What ranking is the todo (i.e. position in the list)?

There's no reason users need to see a delete button (outside of affordance for those unfamiliar with the UI)

## Future enhancements
To avoid layout shift, I still prevent text from being displayed within the area that the delete button occupies. This works, but does mean that we're not using that valuable real-estate on the main view.

<img width="486" alt="image" src="https://github.com/JonShort/tododay/assets/21317379/d37d5c63-bcdd-4b07-9216-239df8d2f9e7">

By design tododay encourages short, snappy todos so lengthy todos are hopefully uncommon enough for it to be ok here

## Before
<img width="306" alt="image" src="https://github.com/JonShort/tododay/assets/21317379/ea7b81cb-e1b1-4994-9b83-91e8a2d2cf2e"><img width="306" alt="image" src="https://github.com/JonShort/tododay/assets/21317379/528ed671-c5c4-4ff9-b1dd-ace0d9750fc4">

## After
<img width="306" alt="image" src="https://github.com/JonShort/tododay/assets/21317379/8dd28ad6-abb3-476d-9bf8-69208ebef77a"><img width="306" alt="image" src="https://github.com/JonShort/tododay/assets/21317379/748e0f86-ca96-4306-917d-84b7b9e94d56">